### PR TITLE
修复内容过长 TableElement 显示会被截断的问题

### DIFF
--- a/src/main/java/com/taobao/text/ui/Layout.java
+++ b/src/main/java/com/taobao/text/ui/Layout.java
@@ -215,11 +215,20 @@ public abstract class Layout {
         }
       }
 
-      //
+      //  totalLength < tty length
       if (totalLength > 0 && totalLength <= length) {
         return ret;
       } else if (totalLength > length) {
-        return Arrays.copyOf(ret, length);
+        // when totalLength still more than tty length, cut Array
+        // prevent ArrayOutoffBounds
+        int len = 0;
+        for(int i = 0; i < actualLengths.length; i++){
+          len += actualLengths[i];
+          if(len > length){
+            break;
+          }
+        }
+        return Arrays.copyOf(ret, len);
       } else {
         return null;
       }

--- a/src/main/java/com/taobao/text/ui/Layout.java
+++ b/src/main/java/com/taobao/text/ui/Layout.java
@@ -216,8 +216,10 @@ public abstract class Layout {
       }
 
       //
-      if (totalLength > 0) {
+      if (totalLength > 0 && totalLength <= length) {
         return ret;
+      } else if (totalLength > length) {
+        return Arrays.copyOf(ret, length);
       } else {
         return null;
       }

--- a/src/main/java/com/taobao/text/ui/Layout.java
+++ b/src/main/java/com/taobao/text/ui/Layout.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (C) 2012 eXo Platform SAS.
  *
@@ -177,10 +178,7 @@ public abstract class Layout {
       }
 
       //
-      int index = minLengths.length - 1;
-      while (totalLength > length && index >= 0) {
-        int delta = totalLength - length;
-        int bar = actualLengths[index] - minLengths[index];
+      if(totalLength > length) {
 
         int ave = 0;
         for (int i = 0; i < actualLengths.length; i++) {
@@ -188,46 +186,49 @@ public abstract class Layout {
         }
         ave /= actualLengths.length;
 
-        if (delta <= bar) {
-          // We are done
-          totalLength = length;
-          ret[index] -= delta;
-        } else {
-          int foo = actualLengths[index];
-          if (spaced) {
-            if (index > 0) {
-              foo++;
+        int index = minLengths.length - 1;
+        while (totalLength > length && index >= 0) {
+          int delta = totalLength - length;
+          int bar = actualLengths[index] - minLengths[index];
+
+          if (delta <= bar) {
+            // We are done
+            totalLength = length;
+            ret[index] -= delta;
+          } else {
+            int foo = actualLengths[index];
+            if (spaced) {
+              if (index > 0) {
+                foo++;
+              }
             }
-          }
+            // cut
+            if (foo > ave) {
+              float ratio = length / (totalLength * 1.0f);
+              int afterCut = (int) (ratio * foo);
+              ret[index] = afterCut;
+              totalLength -= (foo - afterCut);
+            }
 
-          if (foo > ave) {
-            float ratio = length / (totalLength * 1.0f);
-            int afterCut = (int) (ratio * foo);
-            ret[index] = afterCut;
-            totalLength -= (foo - afterCut);
+            index--;
           }
-
-          index--;
         }
       }
 
       //
       if (totalLength > 0) {
         return ret;
-        }
       } else {
         return null;
       }
     }
   };
 /*
-
   public static final ColumnLayout DISTRIBUTED = new ColumnLayout() {
     @Override
     public int[] compute(Border border, int width, int[] widths, int[] minWidths) {
       int index = 0;
       while (true) {
-
         // Compute now the number of chars
         boolean done = false;
         int total = 0;
@@ -245,15 +246,12 @@ public abstract class Layout {
             }
           }
         }
-
         // It's not valid
         if (total == 0) {
           return null;
         }
-
         //
         int delta = width - total;
-
         //
         if (delta == 0) {
           break;
@@ -267,7 +265,6 @@ public abstract class Layout {
           }
           index = (index + 1) % widths.length;
         } else {
-
           // First try to remove from a column above min size
           int found = -1;
           for (int i = widths.length - 1;i >= 0;i--) {
@@ -280,7 +277,6 @@ public abstract class Layout {
               break;
             }
           }
-
           // If we haven't found a victim then we consider removing a column
           if (found == -1) {
             for (int i = widths.length - 1;i >= 0;i--) {
@@ -290,7 +286,6 @@ public abstract class Layout {
               }
             }
           }
-
           // We couldn't find any solution we give up
           if (found == -1) {
             break;
@@ -299,7 +294,6 @@ public abstract class Layout {
           }
         }
       }
-
       //
       return widths;
     }

--- a/src/main/java/com/taobao/text/ui/Layout.java
+++ b/src/main/java/com/taobao/text/ui/Layout.java
@@ -181,6 +181,13 @@ public abstract class Layout {
       while (totalLength > length && index >= 0) {
         int delta = totalLength - length;
         int bar = actualLengths[index] - minLengths[index];
+
+        int ave = 0;
+        for (int i = 0; i < actualLengths.length; i++) {
+          ave += actualLengths[i];
+        }
+        ave /= actualLengths.length;
+
         if (delta <= bar) {
           // We are done
           totalLength = length;
@@ -192,18 +199,21 @@ public abstract class Layout {
               foo++;
             }
           }
-          totalLength -= foo;
-          ret[index] = 0;
+
+          if (foo > ave) {
+            float ratio = length / (totalLength * 1.0f);
+            int afterCut = (int) (ratio * foo);
+            ret[index] = afterCut;
+            totalLength -= (foo - afterCut);
+          }
+
           index--;
         }
       }
 
       //
       if (totalLength > 0) {
-        if (index == minLengths.length - 1) {
-          return ret;
-        } else {
-          return Arrays.copyOf(ret, index + 1);
+        return ret;
         }
       } else {
         return null;

--- a/src/test/java/com/taobao/text/ui/example/TableExample.java
+++ b/src/test/java/com/taobao/text/ui/example/TableExample.java
@@ -13,12 +13,15 @@ import com.taobao.text.ui.Overflow;
 import com.taobao.text.ui.TableElement;
 import com.taobao.text.util.RenderUtil;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 public class TableExample {
 
     @Test
     public void test1() {
         // header定义
-        String[] fields = { "name", "age" };
+        String[] fields = {"name", "age"};
 
         // 设置两列的比例是1:1，如果不设置的话，列宽是自动按元素最长的处理。
         // 设置table的外部边框，默认是没有外边框
@@ -44,5 +47,76 @@ public class TableExample {
 
         // 默认输出宽度是80
         System.err.println(RenderUtil.render(tableElement));
+    }
+
+
+    @Test
+    public void testTableWithLabel() {
+        TableElement table = new TableElement().leftCellPadding(1).rightCellPadding(1);
+        table.row(true, label("timestamp").style(Decoration.bold.bold()),
+                label("class").style(Decoration.bold.bold()),
+                label("method").style(Decoration.bold.bold()),
+                label("total").style(Decoration.bold.bold()),
+                label("success").style(Decoration.bold.bold()),
+                label("fail").style(Decoration.bold.bold()),
+                label("avg-rt(ms)").style(Decoration.bold.bold()),
+                label("fail-rate").style(Decoration.bold.bold()));
+        table.row(
+                new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date()),
+                "com.taobao.text.ui.example,IAmToooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooolong",
+                "SuperLooooooooooooooooooooooooooooooooooooooooogMethod",
+                "10000",
+                "10000",
+                "99999",
+                "0.01",
+                "0.99%"
+        );
+        System.out.println(RenderUtil.render(table));
+    }
+
+    @Test
+    public void testTableInTable() {
+        TableElement table = new TableElement().leftCellPadding(1).rightCellPadding(1);
+        table.row(true, label("timestamp").style(Decoration.bold.bold()),
+                label("class").style(Decoration.bold.bold()),
+                label("method").style(Decoration.bold.bold()),
+                label("total").style(Decoration.bold.bold()),
+                label("success").style(Decoration.bold.bold()),
+                label("fail").style(Decoration.bold.bold()),
+                label("avg-rt(ms)").style(Decoration.bold.bold()),
+                label("fail-rate").style(Decoration.bold.bold()));
+        table.row(
+                new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date()),
+                "com.taobao.text.ui.example,IAmlong",
+                "SuperLooooooooooooooooooooooooooooooooooooooooogMethod",
+                "10000",
+                "10000",
+                "99999",
+                "0.01",
+                "0.99%"
+        );
+
+
+        TableElement table2 = new TableElement().leftCellPadding(1).rightCellPadding(1);
+        table2.row(true, label("timestamp").style(Decoration.bold.bold()),
+                label("class").style(Decoration.bold.bold()),
+                label("method").style(Decoration.bold.bold()),
+                label("total").style(Decoration.bold.bold()),
+                label("success").style(Decoration.bold.bold()),
+                label("fail").style(Decoration.bold.bold()),
+                label("avg-rt(ms)").style(Decoration.bold.bold()),
+                label("fail-rate").style(Decoration.bold.bold()));
+        table2.row(
+                new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date()),
+                "com.taobao.text.ui.example,IAmlong",
+                "SuperLooooooooooooooooooooooooooooooooooooooooogMethod",
+                "10000",
+                "10000",
+                "99999",
+                "0.01",
+                "0.99%"
+        );
+        table.row("Hello World").row(table2).row(" Hello, Alibaba MiddleWare ");
+        System.out.println(RenderUtil.render(table));
     }
 }


### PR DESCRIPTION
尝试修复 Arthas [https://github.com/alibaba/arthas/issues/1170](https://github.com/alibaba/arthas/issues/1170)  

- 长类名 

![image](https://user-images.githubusercontent.com/21981606/82638377-603e8380-9c39-11ea-89f5-8fd311beb32f.png)

- 长类名&方法

![image](https://user-images.githubusercontent.com/21981606/82638622-dcd16200-9c39-11ea-8766-23840e0dfb61.png)

- 一般情况
![image](https://user-images.githubusercontent.com/21981606/82638856-2fab1980-9c3a-11ea-9f5b-61ae9d6b03e5.png)



思路是 求数组的平均值 然后 `大于`平均值的 就会被 按比例 ( 长度 / tty长度) 对过长的字符串把需要占用的长度减少 

